### PR TITLE
chore: add CODEOWNERS file to define default repository owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @otaku0304 will be requested for
+# review when someone opens a pull request.
+*       @otaku@0304


### PR DESCRIPTION
### Summary  
This PR adds a `CODEOWNERS` file to the repository to enforce code review rules and automatically assign reviewers.

### Changes  
- Added `.github/CODEOWNERS` file  
- Assigned `@Otaku0304` as the default reviewer for all files  

### Why?  
- Ensures that all PRs require a review from the repository owner before merging  
- Helps maintain code quality and enforce best practices  

### Notes  
- This rule will apply to all future PRs.  
- If needed, additional contributors can be added to the `CODEOWNERS` file.  
