### PR TITLE
fix: correct CODEOWNERS entry formatting

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 # the repo. Unless a later match takes precedence,
 # @otaku0304 will be requested for
 # review when someone opens a pull request.
-*       @otaku@0304
+*       @otaku0304


### PR DESCRIPTION
### Summary  
This PR fixes the `CODEOWNERS` file by correcting the GitHub username format and ensuring the assigned user has write access.

### Changes  
- Fixed incorrect username format (`@otaku@0304` → `@Otaku0304`).  
- Ensured that the assigned user has the correct permissions.  

### Why?  
- The previous version caused an error due to an invalid username format.  
- This fix ensures that pull requests correctly assign the code owner for review.  
