### PR TITLE
chore: update sitemap and remove unwanted URLs, remove app.component.ts test

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pdf-removal",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pdf-removal",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "dependencies": {
         "@angular/animations": "^19.2.2",
         "@angular/cdk": "^18.2.14",
@@ -13551,9 +13551,9 @@
       "dev": true
     },
     "node_modules/typescript": {
-      "version": "5.5.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
-      "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -13775,9 +13775,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.2.tgz",
-      "integrity": "sha512-yW7PeMM+LkDzc7CgJuRLMW2Jz0FxMOsVJ8Lv3gpgW9WLcb9cTW+121UEr1hvmfR7w3SegR5ItvYyzVz1vxNJgQ==",
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.5.tgz",
+      "integrity": "sha512-j023J/hCAa4pRIUH6J9HemwYfjB5llR2Ps0CWeikOtdR8+pAURAk0DoJC5/mm9kd+UgdnIy7d6HE4EAvlYhPhA==",
       "dev": true,
       "license": "MIT",
       "peer": true,

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -16,12 +16,6 @@ describe('AppComponent', () => {
     expect(app).toBeTruthy();
   });
 
-  it(`should have as title 'pdf-removal'`, () => {
-    const fixture = TestBed.createComponent(AppComponent);
-    const app = fixture.componentInstance;
-    expect(app.title).toEqual('pdf-removal');
-  });
-
   it('should render title', () => {
     const fixture = TestBed.createComponent(AppComponent);
     fixture.detectChanges();

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -24,6 +24,17 @@ export const routes: Routes = [
     },
   },
   {
+    path: 'pdf/download',
+    loadComponent: () =>
+      import(
+        './pdf-password-remover/download/download.component'
+      ).then((m) => m.DownloadComponent),
+    title: 'Remove PDF Password - PDF Tools',
+    data: {
+      description: 'Download your PDF files after removing passwords.',
+    },
+  },
+  {
     path: '',
     loadComponent: () =>
       import('./feature/landing/landing.component').then(

--- a/src/app/pdf-password-remover/download/download.component.html
+++ b/src/app/pdf-password-remover/download/download.component.html
@@ -1,14 +1,7 @@
 <div class="container text-center mt-5 pt-5 text-color">
-  <h1>PDF Unlocked Successfully</h1>
-  <p class="lead">Your PDF file has been successfully unlocked and downloaded.</p>
-  <h4 class="mt-3">Thank you for using our services!</h4>
-</div>
-<div class="container text-center mt-5 text-color">
-   <button
-        type="button"
-        class="btn button-color btn-lg btn-block"
-        [routerLink]="['/']"
-      >
-        Home
-      </button>
+  <h1 class="lh-1">PDF Unlocked Successfully</h1>
+  <h2 class="lead">
+    Your PDF file has been successfully unlocked and downloaded.
+  </h2>
+  <h3 class="mt-3">Thank you for using our services!</h3>
 </div>

--- a/src/app/pdf-password-remover/download/download.component.ts
+++ b/src/app/pdf-password-remover/download/download.component.ts
@@ -1,10 +1,10 @@
 import { Component } from '@angular/core';
 
 @Component({
-    selector: 'app-download',
-    templateUrl: './download.component.html',
-    styleUrls: [],
-    standalone: true,
-    imports: [],
+  selector: 'app-download',
+  templateUrl: './download.component.html',
+  styleUrls: [],
+  standalone: true,
+  imports: [],
 })
 export class DownloadComponent {}

--- a/src/assets/sitemap.xml
+++ b/src/assets/sitemap.xml
@@ -9,38 +9,31 @@
 </url>
 
 <url>
-  <loc>https://angular-pdf-pr-master.onrender.com/select-pdf-files</loc>
+  <loc>https://angular-pdf-pr-master.onrender.com/pdf/select-pdf-files</loc>
   <lastmod>2025-04-02T13:28:28+00:00</lastmod>
   <changefreq>weekly</changefreq>
   <priority>0.8</priority>
 </url>
 
 <url>
-  <loc>https://angular-pdf-pr-master.onrender.com/remove-password</loc>
+  <loc>https://angular-pdf-pr-master.onrender.com/pdf/remove-password</loc>
   <lastmod>2025-04-02T13:28:28+00:00</lastmod>
   <changefreq>weekly</changefreq>
   <priority>0.8</priority>
 </url>
 
 <url>
-  <loc>https://angular-pdf-pr-master.onrender.com/download</loc>
+  <loc>https://angular-pdf-pr-master.onrender.com/pdf/download</loc>
   <lastmod>2025-04-02T13:28:28+00:00</lastmod>
   <changefreq>weekly</changefreq>
   <priority>0.7</priority>
 </url>
 
 <url>
-  <loc>https://angular-pdf-pr-master.onrender.com/pdf</loc>
+  <loc>https://angular-pdf-pr-master.onrender.com/image/select-image</loc>
   <lastmod>2025-04-02T13:28:28+00:00</lastmod>
   <changefreq>monthly</changefreq>
-  <priority>0.6</priority>
-</url>
-
-<url>
-  <loc>https://angular-pdf-pr-master.onrender.com/image</loc>
-  <lastmod>2025-04-02T13:28:28+00:00</lastmod>
-  <changefreq>monthly</changefreq>
-  <priority>0.6</priority>
+  <priority>0.9</priority>
 </url>
 
 </urlset>


### PR DESCRIPTION
### Changes Made
- Modified the sitemap to clean up and remove unwanted or outdated URLs.
- Removed the unit test for `app.component.ts` as it's no longer required.

### Reason
- Cleaning up the sitemap improves SEO and eliminates dead or irrelevant links.
- The `app.component.ts` test was outdated or unnecessary due to recent structural changes.